### PR TITLE
Fix to enable "extension" write support

### DIFF
--- a/src/main/java/org/onebusaway/csv_entities/schema/EntitySchema.java
+++ b/src/main/java/org/onebusaway/csv_entities/schema/EntitySchema.java
@@ -36,6 +36,7 @@ public class EntitySchema extends BaseEntitySchema {
     super(schema);
     _filename = schema._filename;
     _required = schema._required;
+    _extensions = new ArrayList<ExtensionEntitySchema>(schema._extensions);
   }
 
   public String getFilename() {


### PR DESCRIPTION
Fixes the EntitySchema copy constructor to also copy the extensions. A separate pull request to `onebusaway-gtfs-modules` contains a test.