### PR TITLE
The DelimitedTextParser in CSVLibrary should not be statically typed.

### DIFF
--- a/src/main/java/org/onebusaway/csv_entities/CSVLibrary.java
+++ b/src/main/java/org/onebusaway/csv_entities/CSVLibrary.java
@@ -34,8 +34,7 @@ import java.util.List;
  */
 public class CSVLibrary {
 
-  private static final DelimitedTextParser _parser = new DelimitedTextParser(
-      ',');
+  private final DelimitedTextParser _parser = new DelimitedTextParser(',');
 
   public static String escapeValue(String value) {
     if (value.indexOf(',') != -1 || value.indexOf('"') != -1)


### PR DESCRIPTION
Otherwise, it leads to bugs where multiple instances of CsvLibrary are created and configured differently.