### PR TITLE
Platform-independent tests

### DIFF
--- a/src/test/java/org/onebusaway/csv_entities/IndividualCsvEntityWriterTest.java
+++ b/src/test/java/org/onebusaway/csv_entities/IndividualCsvEntityWriterTest.java
@@ -55,7 +55,7 @@ public class IndividualCsvEntityWriterTest {
     writer.close();
 
     String content = output.getBuffer().toString();
-    assertEquals("name,value\nalice,a\nbob,b\n", content);
+    assertEquals("name,value" + System.lineSeparator() + "alice,a" + System.lineSeparator() + "bob,b" + System.lineSeparator(), content);
   }
 
   @Test
@@ -86,7 +86,7 @@ public class IndividualCsvEntityWriterTest {
     writer.close();
 
     String content = output.getBuffer().toString();
-    assertEquals("value,name\na,alice\nb,bob\n", content);
+    assertEquals("value,name" + System.lineSeparator() + "a,alice" + System.lineSeparator() + "b,bob" + System.lineSeparator(), content);
   }
 
 }


### PR DESCRIPTION
Tests were not platform-independent due to hard-coded line separators.

Note that this will still fail until #9 is merged as it relies on `System.lineSeparator()` which was new in Java 7.