### PR TITLE
Call AbstractFieldMapping.setIsSetMethod() even on non-default field mappings

### DIFF
--- a/src/main/java/org/onebusaway/csv_entities/schema/AbstractEntitySchemaFactoryImpl.java
+++ b/src/main/java/org/onebusaway/csv_entities/schema/AbstractEntitySchemaFactoryImpl.java
@@ -400,8 +400,6 @@ public abstract class AbstractEntitySchemaFactoryImpl implements
       DefaultFieldMapping m = new DefaultFieldMapping(entityClass,
           csvFieldName, objFieldName, objFieldType, required);
 
-      setIsSetMethod(entityClass, field, m);
-
       mapping = m;
     }
 
@@ -416,27 +414,23 @@ public abstract class AbstractEntitySchemaFactoryImpl implements
         fm.setDefaultValue(fieldMappingBean.getDefaultValue());
       }
 
-      setIsSetMethod(entityClass, field, fm);
+      try {
+        String name = field.getName();
+        String isFieldSet = "is" + Character.toUpperCase(name.charAt(0))
+                + name.substring(1) + "Set";
+
+        Method method = entityClass.getMethod(isFieldSet);
+        if (method != null
+                && (method.getReturnType() == Boolean.class || method.getReturnType() == Boolean.TYPE)) {
+          fm.setIsSetMethod(method);
+        }
+      } catch (Exception ex) {
+        // We ignore this
+      }
 
     }
 
     return mapping;
-  }
-
-  private static void setIsSetMethod(Class<?> entityClass, Field field, AbstractFieldMapping fm) {
-    try {
-      String name = field.getName();
-      String isFieldSet = "is" + Character.toUpperCase(name.charAt(0))
-              + name.substring(1) + "Set";
-
-      Method method = entityClass.getMethod(isFieldSet);
-      if (method != null
-              && (method.getReturnType() == Boolean.class || method.getReturnType() == Boolean.TYPE)) {
-        fm.setIsSetMethod(method);
-      }
-    } catch (Exception ex) {
-      // We ignore this
-    }
   }
 
   private String getEntityClassAsEntityName(Class<?> entityClass) {

--- a/src/main/java/org/onebusaway/csv_entities/schema/AbstractEntitySchemaFactoryImpl.java
+++ b/src/main/java/org/onebusaway/csv_entities/schema/AbstractEntitySchemaFactoryImpl.java
@@ -400,18 +400,7 @@ public abstract class AbstractEntitySchemaFactoryImpl implements
       DefaultFieldMapping m = new DefaultFieldMapping(entityClass,
           csvFieldName, objFieldName, objFieldType, required);
 
-      try {
-        String name = field.getName();
-        String isFieldSet = "is" + Character.toUpperCase(name.charAt(0))
-            + name.substring(1) + "Set";
-        Method method = entityClass.getMethod(isFieldSet);
-        if (method != null
-            && (method.getReturnType() == Boolean.class || method.getReturnType() == Boolean.TYPE)) {
-          m.setIsSetMethod(method);
-        }
-      } catch (Exception ex) {
-        // We ignore this
-      }
+      setIsSetMethod(entityClass, field, m);
 
       mapping = m;
     }
@@ -426,9 +415,28 @@ public abstract class AbstractEntitySchemaFactoryImpl implements
       if (fieldMappingBean.getDefaultValue() != null) {
         fm.setDefaultValue(fieldMappingBean.getDefaultValue());
       }
+
+      setIsSetMethod(entityClass, field, fm);
+
     }
 
     return mapping;
+  }
+
+  private static void setIsSetMethod(Class<?> entityClass, Field field, AbstractFieldMapping fm) {
+    try {
+      String name = field.getName();
+      String isFieldSet = "is" + Character.toUpperCase(name.charAt(0))
+              + name.substring(1) + "Set";
+
+      Method method = entityClass.getMethod(isFieldSet);
+      if (method != null
+              && (method.getReturnType() == Boolean.class || method.getReturnType() == Boolean.TYPE)) {
+        fm.setIsSetMethod(method);
+      }
+    } catch (Exception ex) {
+      // We ignore this
+    }
   }
 
   private String getEntityClassAsEntityName(Class<?> entityClass) {

--- a/src/test/java/org/onebusaway/csv_entities/IndividualCsvEntityWriterTest.java
+++ b/src/test/java/org/onebusaway/csv_entities/IndividualCsvEntityWriterTest.java
@@ -89,4 +89,33 @@ public class IndividualCsvEntityWriterTest {
     assertEquals("value,name\na,alice\nb,bob\n", content);
   }
 
+  @Test
+  public void testDefaultValues() {
+    DefaultEntitySchemaFactory factory = new DefaultEntitySchemaFactory();
+
+    CsvEntityContextImpl context = new CsvEntityContextImpl();
+    StringWriter output = new StringWriter();
+
+    IndividualCsvEntityWriter writer = new IndividualCsvEntityWriter(context,
+            factory.getSchema(OptionalFieldTestBean.class), new PrintWriter(output));
+
+    OptionalFieldTestBean tb = new OptionalFieldTestBean();
+
+    tb.setIntValue(1234);
+    tb.setDoubleValue(2345.8);
+
+    writer.handleEntity(tb);
+
+    tb.clearIntValue();
+    tb.clearDoubleValue();
+
+    writer.handleEntity(tb);
+
+    writer.close();
+
+    String content = output.getBuffer().toString();
+    assertEquals("int_value,double_value" + System.lineSeparator() +
+            "1234,2345.80" + System.lineSeparator() + "," + System.lineSeparator(), content);
+  }
+
 }

--- a/src/test/java/org/onebusaway/csv_entities/OptionalFieldTestBean.java
+++ b/src/test/java/org/onebusaway/csv_entities/OptionalFieldTestBean.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (C) 2011 Brian Ferris <bdferris@onebusaway.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.onebusaway.csv_entities;
+
+import org.onebusaway.csv_entities.schema.DecimalFieldMappingFactory;
+import org.onebusaway.csv_entities.schema.DecimalFieldMappingFactory.NumberFormatAnnotation;
+import org.onebusaway.csv_entities.schema.annotations.CsvField;
+import org.onebusaway.csv_entities.schema.annotations.CsvFields;
+
+@CsvFields(filename = "test_beans")
+public class OptionalFieldTestBean {
+
+    private static final int DEFAULT_VALUE = -999;
+
+    @CsvField(optional = true)
+    private int intValue = DEFAULT_VALUE;
+
+    @CsvField(optional = true, mapping = DecimalFieldMappingFactory.class)
+    @NumberFormatAnnotation("0.00")
+    private double doubleValue = DEFAULT_VALUE;
+
+    public boolean isIntValueSet() {
+        return intValue != DEFAULT_VALUE;
+    }
+
+    public int getIntValue() {
+        return intValue;
+    }
+
+    public void setIntValue(final int intValue) {
+        this.intValue = intValue;
+    }
+
+    public void clearIntValue() {
+        this.intValue = DEFAULT_VALUE;
+    }
+
+    public boolean isDoubleValueSet() {
+        return doubleValue != DEFAULT_VALUE;
+    }
+
+    public double getDoubleValue() {
+        return doubleValue;
+    }
+
+    public void setDoubleValue(double doubleValue) {
+        this.doubleValue = doubleValue;
+    }
+
+    public void clearDoubleValue() {
+        this.doubleValue = DEFAULT_VALUE;
+    }
+
+}


### PR DESCRIPTION
The symptom here is that an optional field in `onebusaway-gtfs-modules` using `LatLonFieldMappingFactory`  was having its default value serialized.  Further debugging revealed that the field's `isSet` method was not being called.  Further tracing revealed that this only occurred with non-default field mappings, and this was due to `AbstractFieldMapping.setIsSetMethod()` not being called on non-default field mappings after they are instantiated.