### PR TITLE
Remove cached EntitySchemas if Extensions are added to an entity

### DIFF
--- a/src/main/java/org/onebusaway/csv_entities/schema/AbstractEntitySchemaFactoryImpl.java
+++ b/src/main/java/org/onebusaway/csv_entities/schema/AbstractEntitySchemaFactoryImpl.java
@@ -75,6 +75,8 @@ public abstract class AbstractEntitySchemaFactoryImpl implements
       _extensionsByClass.put(type, extensionTypes);
     }
     extensionTypes.add(extensionType);
+
+    _schemasByClass.remove(type);
   }
 
   /****

--- a/src/test/java/org/onebusaway/csv_entities/schema/AbstractEntitySchemaFactoryImplTest.java
+++ b/src/test/java/org/onebusaway/csv_entities/schema/AbstractEntitySchemaFactoryImplTest.java
@@ -53,6 +53,18 @@ public class AbstractEntitySchemaFactoryImplTest {
     assertEquals("value", field.getCsvFieldName());
   }
 
+  @Test
+  public void testExtensionsAfterSchemaIsCached() {
+    SchemaFactory factory = new SchemaFactory();
+    EntitySchema entitySchema = factory.getSchema(BaseBean.class);
+    assertTrue(entitySchema.getExtensions().isEmpty());
+
+    factory.addExtension(BaseBean.class, ExtensionBean.class);
+
+    entitySchema = factory.getSchema(BaseBean.class);
+    assertEquals(1, entitySchema.getExtensions().size());
+  }
+
   private class SchemaFactory extends AbstractEntitySchemaFactoryImpl {
     @Override
     protected void processBeanDefinitions() {


### PR DESCRIPTION
The caching makes it hard to add extensions to existing factories such as those used by `GtfsReader`/`GtfsTransformer` in _onebusaway-gtfs-modules_.